### PR TITLE
IO2019TEAM-103 Fix sprint creation condition

### DIFF
--- a/papaya-web/src/main/java/pl/edu/agh/papaya/rest/projects/service/SprintsRestService.java
+++ b/papaya-web/src/main/java/pl/edu/agh/papaya/rest/projects/service/SprintsRestService.java
@@ -162,6 +162,6 @@ public class SprintsRestService {
 
     public boolean isInOverlapWithLastSprint(Project project, LocalDateTimePeriod durationPeriod) {
         Optional<Sprint> lastSprintOpt = sprintService.getLastInProject(project.getId());
-        return lastSprintOpt.isEmpty() || durationPeriod.isAfter(lastSprintOpt.get().getDurationPeriod());
+        return lastSprintOpt.isPresent() && !durationPeriod.isAfter(lastSprintOpt.get().getDurationPeriod());
     }
 }


### PR DESCRIPTION
Oryginalnie było tak:
```
Optional<Sprint> lastSprintOpt = sprintService.getLastInProject(project.getId());
lastSprintOpt.ifPresent(lastSprint -> {
        if (!durationPeriod.isAfter(lastSprint.getDurationPeriod())) {
            throw new IllegalStateException("Cannot create sprint starting before the last one ended");        
        }
});
```