### PR TITLE
IO2019TEAM-126 Fix NPE when calling getSprintStats

### DIFF
--- a/papaya-core/src/main/java/pl/edu/agh/papaya/model/SprintStats.java
+++ b/papaya-core/src/main/java/pl/edu/agh/papaya/model/SprintStats.java
@@ -24,7 +24,7 @@ public class SprintStats {
 
     private Double coefficient;
 
-    private Double averageCoefficientCache;
+    private Double averageCoefficientCache = 0d;
 
     public void updateCoefficient(Duration totalDeclaredTime) {
         if (timeBurned != null && totalDeclaredTime != null) {


### PR DESCRIPTION
Jeśli embedded ma wszystkie pola wynullowane, sam staje się nullem 