### PR TITLE
IO2019TEAM-130 Fix coefficient being equal to a very big number

### DIFF
--- a/papaya-core/src/main/java/pl/edu/agh/papaya/model/SprintStats.java
+++ b/papaya-core/src/main/java/pl/edu/agh/papaya/model/SprintStats.java
@@ -27,7 +27,7 @@ public class SprintStats {
     private Double averageCoefficientCache = 0d;
 
     public void updateCoefficient(Duration totalDeclaredTime) {
-        if (timeBurned != null && totalDeclaredTime != null && !totalDeclaredTime.isZero()) {
+        if (timeBurned != null && totalDeclaredTime != null && !totalDeclaredTime.isZero() && !timeBurned.isZero()) {
             this.coefficient = DoubleUtil.saturated(
                     (double) totalDeclaredTime.toMinutes() / (double) timeBurned.toMinutes(),
                     MIN_COEFFICIENT, MAX_COEFFICIENT


### PR DESCRIPTION
Oooo, jeszcze to miałam gdzieś poprawione i zapomniałam. Współczynnik nam się zwraca jako `10000000`, jak `timeBurned` jest równe zero, więc chyba lepiej jest tak nie robić

(`IO2019TEAM-130`, bo akurat byłam na takim branchu, a przecież nie będę tworzyła nowego)